### PR TITLE
Add version key to manifest.json

### DIFF
--- a/custom_components/ups/manifest.json
+++ b/custom_components/ups/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "ups",
     "name": "Ups",
+    "version": "1.0.0",
     "documentation": "https://www.home-assistant.io/components/ups",
     "requirements": [
       "upsmychoice==1.0.6"


### PR DESCRIPTION
Required to load extension. https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions